### PR TITLE
Support cloudfront urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,12 @@ const isCssLink = require('hast-util-is-css-link')
 
 let unsafeInlineStyles = process.env.CSP_HEADERS_UNSAFE_STYLES ?? false
 let reportUrl = process.env.CSP_HEADERS_REPORT_URL
+let allowCloudfrontSource = process.env.CSP_HEADERS_ALLOW_CLOUDFRONT_SOURCE
 
 module.exports= {
     onPostBuild: async function({constants, utils, inputs}) {
         unsafeInlineStyles = inputs.unsafeStyles ?? unsafeInlineStyles
+        allowCloudfrontSource = inputs.allowCloudfrontSource ?? allowCloudfrontSource
         reportUrl = inputs.reportUrl ?? reportUrl
         try {
             const htmlFiles = await getHtmlFilesFromDir(constants.PUBLISH_DIR)
@@ -115,7 +117,7 @@ const url = filePath.replace(publishPath, '').replace(/^\/index.html/, '/');
 return (
 `${url} ${reportToHeader === '' ? '' : `
     ${reportToHeader}`}
-    Content-Security-Policy: default-src 'self'; script-src 'self' 'strict-dynamic' 'unsafe-inline' ${hashes['script'].join(" ")}; style-src 'self' 'unsafe-inline' ${unsafeInlineStyles ? '' : hashes['style'].join(' ')}; ${ reportUrl == null ? null : `report-to netlify-csp-endpoint; report-uri ${reportUrl};`}
+    Content-Security-Policy: default-src 'self' ${allowCloudfrontSource ? `'https://*.cloudfront.net'` : ''}; script-src 'self' 'strict-dynamic' 'unsafe-inline' ${hashes['script'].join(" ")}; style-src 'self' 'unsafe-inline' ${unsafeInlineStyles ? '' : hashes['style'].join(' ')}; ${ reportUrl == null ? null : `report-to netlify-csp-endpoint; report-uri ${reportUrl};`}
 `)
 }
 /**

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,4 +4,5 @@ inputs:
     description: Value of "true" allows unsafe-inline styles in your site. This leaves the style tag hashes out of your CSP headers. This gets around issues from Netlify transforming urls and other things after the plugin runs. Can instead use CSP_HEADERS_UNSAFE_STYLES environment variable. 
   - name: reportUrl
     description: url for the CSP-reports. Useful for monitoring/debugging issues with the CSP configuration. 
-    
+  - name: allowCloudfrontSource
+    description: allows cloudfront sources as part of the "default src" CSP header. This should work to prevent asset optimized content that's not a script or style tag from being blocked by CSP headers. But malicious attackers could potentially use a cloudfront url to allow malicious content. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-plugin-csp-headers",
-  "version": "0.0.1-alpha.06",
+  "version": "0.0.1-alpha.07",
   "main": "index.js",
   "repository": "https://github.com/mdarrik/netlify-plugin-csp-hash.git",
   "author": "Darrik <30670444+mdarrik@users.noreply.github.com>",


### PR DESCRIPTION
Adds an option to support some of Netlify's cloudfront urls. Does come with some minor risks, but still less than others. 